### PR TITLE
fix: replace compiler fences with potentially-synchronizing assembly

### DIFF
--- a/src/imp/aarch64.rs
+++ b/src/imp/aarch64.rs
@@ -10,7 +10,10 @@ pub fn read_disable() -> Flags {
             "mrs {}, DAIF",
             "msr DAIFSet, 0b111",
             out(reg) daif,
-            options(nomem, nostack)
+            // Omit `nomem` to imitate a lock acquire.
+            // Otherwise, the compiler is free to move
+            // reads and writes through this asm block.
+            options(nostack)
         );
     }
     daif
@@ -19,6 +22,13 @@ pub fn read_disable() -> Flags {
 #[inline]
 pub fn restore(daif: Flags) {
     unsafe {
-        asm!("msr DAIF, {}", in(reg) daif, options(nomem, nostack));
+        asm!(
+            "msr DAIF, {}",
+            in(reg) daif,
+            // Omit `nomem` to imitate a lock release.
+            // Otherwise, the compiler is free to move
+            // reads and writes through this asm block.
+            options(nostack)
+        );
     }
 }

--- a/src/imp/riscv64.rs
+++ b/src/imp/riscv64.rs
@@ -12,7 +12,10 @@ pub fn read_disable() -> Flags {
             // Set SIE and MIE
             "csrrci {rd}, mstatus, 0b1010",
             rd = out(reg) flags,
-            options(nomem, nostack)
+            // Omit `nomem` to imitate a lock acquire.
+            // Otherwise, the compiler is free to move
+            // reads and writes through this asm block.
+            options(nostack)
         );
     }
     flags
@@ -25,7 +28,10 @@ pub fn restore(flags: Flags) {
             // Atomic Set Bits in CSR
             "csrs mstatus, {rs1}",
             rs1 = in(reg) flags,
-            options(nomem, nostack)
+            // Omit `nomem` to imitate a lock release.
+            // Otherwise, the compiler is free to move
+            // reads and writes through this asm block.
+            options(nostack)
         );
     }
 }

--- a/src/imp/x86_64.rs
+++ b/src/imp/x86_64.rs
@@ -12,7 +12,10 @@ pub fn read_disable() -> Flags {
             "pop {}",
             "cli",
             out(reg) rflags,
-            options(nomem, preserves_flags)
+            // Omit `nomem` to imitate a lock acquire.
+            // Otherwise, the compiler is free to move
+            // reads and writes through this asm block.
+            options(preserves_flags)
         );
     }
 
@@ -25,7 +28,13 @@ pub fn read_disable() -> Flags {
 pub fn restore(enable: Flags) {
     if enable {
         unsafe {
-            asm!("sti", options(nomem, preserves_flags));
+            asm!(
+                "sti",
+                // Omit `nomem` to imitate a lock acquire.
+                // Otherwise, the compiler is free to move
+                // reads and writes through this asm block.
+                options(preserves_flags)
+            );
         }
     }
 }


### PR DESCRIPTION
Compiler fences only synchronize with atomic instructions. When creating a thread-local critical section, we need to prevent reordering of any reads and writes across interrupt toggles, not just atomic ones. To achieve this, we omit `nomem` from `asm!`. Since then, the assembly might potentially perform synchronizing operations such as acquiring or releasing a lock, the compiler won't move any reads and writes through these assembly blocks.

On Unix, the same is achieved by calling an external OS function for managing signals.

See https://github.com/mkroening/interrupt-ref-cell/issues/5#issuecomment-1753047784.