### PR TITLE
fix(aarch64,riscv64): set `perserves_flags` for assembly

### DIFF
--- a/src/imp/aarch64.rs
+++ b/src/imp/aarch64.rs
@@ -13,7 +13,7 @@ pub fn read_disable() -> Flags {
             // Omit `nomem` to imitate a lock acquire.
             // Otherwise, the compiler is free to move
             // reads and writes through this asm block.
-            options(nostack)
+            options(preserves_flags, nostack)
         );
     }
     daif
@@ -28,7 +28,7 @@ pub fn restore(daif: Flags) {
             // Omit `nomem` to imitate a lock release.
             // Otherwise, the compiler is free to move
             // reads and writes through this asm block.
-            options(nostack)
+            options(preserves_flags, nostack)
         );
     }
 }

--- a/src/imp/riscv64.rs
+++ b/src/imp/riscv64.rs
@@ -15,7 +15,7 @@ pub fn read_disable() -> Flags {
             // Omit `nomem` to imitate a lock acquire.
             // Otherwise, the compiler is free to move
             // reads and writes through this asm block.
-            options(nostack)
+            options(preserves_flags, nostack)
         );
     }
     flags
@@ -31,7 +31,7 @@ pub fn restore(flags: Flags) {
             // Omit `nomem` to imitate a lock release.
             // Otherwise, the compiler is free to move
             // reads and writes through this asm block.
-            options(nostack)
+            options(preserves_flags, nostack)
         );
     }
 }


### PR DESCRIPTION
This is an optimization.